### PR TITLE
Add health check endpoint to application

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,3 +59,17 @@ jobs:
         env | grep DB_
         eb init "$EB_APPLICATION_NAME" --region "$AWS_REGION" --platform "Python 3.9"
         eb deploy "$EB_ENVIRONMENT_NAME"
+
+    - name: URL Health Check
+      uses: Jtalk/url-health-check-action@v4
+      with:
+        # Check the following URLs one by one sequentially
+        url: http://nausicaa-app-env.eba-iqpmkjfb.eu-west-1.elasticbeanstalk.com/health
+        # Follow redirects, or just report success on 3xx status codes
+        follow-redirect: false # Optional, defaults to "false"
+        # Fail this action after this many failed attempts
+        max-attempts: 3 # Optional, defaults to 1
+        # Delay between retries
+        retry-delay: 5s # Optional, only applicable to max-attempts > 1
+        # Retry all errors, including 404. This option might trigger curl upgrade.
+        retry-all: false # Optional, defaults to "false"

--- a/nausica-grant-application/application.py
+++ b/nausica-grant-application/application.py
@@ -58,6 +58,11 @@ db.init_app(application)  # Initialize db with app
 # Initialize Flask Migrate
 migrate = Migrate(application, db)
 
+@application.route('/health', methods=['GET'])
+def health_check():
+    """Health check endpoint to return a 200 status."""
+    return jsonify(status="OK"), 200
+
 @application.route("/", methods=['GET', 'POST'])
 def home():
     """Handle POST requests for form submissions."""


### PR DESCRIPTION
Add health check endpoint to application to be able to call as part of the build process to ensure application is built successfully